### PR TITLE
Fix for nil errors on several pages

### DIFF
--- a/app/views/helpers/redmine_category_tree/issue_category_helper.rb
+++ b/app/views/helpers/redmine_category_tree/issue_category_helper.rb
@@ -34,6 +34,7 @@ module RedmineCategoryTree
 		end
 
 		def render_issue_category_with_tree(category)
+      return '' if category.nil?
 			s = ''
 			ancestors = category.root? ? [] : category.ancestors.all
 			if ancestors.any?

--- a/init.rb
+++ b/init.rb
@@ -32,7 +32,12 @@ ActionDispatch::Callbacks.to_prepare do
 	require_dependency 'project'
 	unless Project.included_modules.include?(RedmineCategoryTree::Patches::ProjectPatch)
 		Project.send(:include, RedmineCategoryTree::Patches::ProjectPatch)
-	end
+  end
+
+  require_dependency 'projects_controller'
+  unless ProjectsController.included_modules.include?(RedmineCategoryTree::Patches::ProjectsControllerPatch)
+    ProjectsController.send(:include, RedmineCategoryTree::Patches::ProjectsControllerPatch)
+  end
 	
 	require_dependency 'reports_controller'
   unless ReportsController.included_modules.include?(RedmineCategoryTree::Patches::ReportsControllerPatch)

--- a/lib/redmine_category_tree/patches/issue_categories_controller_patch.rb
+++ b/lib/redmine_category_tree/patches/issue_categories_controller_patch.rb
@@ -11,6 +11,8 @@ module RedmineCategoryTree
 					unloadable
 
 					helper RedmineCategoryTree::IssueCategoryHelper
+
+          alias_method_chain :new, :category_tree
 				end
 			end
 
@@ -18,6 +20,16 @@ module RedmineCategoryTree
 			end
 
 			module InstanceMethods
+        def new_with_category_tree
+          @category = IssueCategory.new(:project_id => @project.id)
+          @category.safe_attributes = params[:issue_category]
+
+          respond_to do |format|
+            format.html
+            format.js
+          end
+        end
+
 			  def move_category
 			    categoryId = params[:id]
 			    direction = params[:direction]

--- a/lib/redmine_category_tree/patches/projects_controller_patch.rb
+++ b/lib/redmine_category_tree/patches/projects_controller_patch.rb
@@ -1,0 +1,24 @@
+require File.dirname(__FILE__) + '/../../../app/views/helpers/redmine_category_tree/issue_category_helper.rb'
+
+module RedmineCategoryTree
+	module Patches
+		module ProjectsControllerPatch
+			def self.included(base) # :nodoc:
+				base.extend(ClassMethods)
+				base.send(:include, InstanceMethods)
+
+				base.class_eval do
+					unloadable
+
+					helper RedmineCategoryTree::IssueCategoryHelper
+				end
+			end
+
+			module ClassMethods
+			end
+
+			module InstanceMethods
+			end
+		end
+	end
+end


### PR DESCRIPTION
This commit fixes error 500 on
- issue list (when there were issues without category)
- issue show (same)
- project settings (missing reference to helper)
- create/edit category (empty category object included in @project.issue_categories because of 'build' in controller method 'new')
