### PR TITLE
Fix for error 500 on Issue show with specific history entry

### DIFF
--- a/lib/redmine_category_tree/patches/issues_helper_patch.rb
+++ b/lib/redmine_category_tree/patches/issues_helper_patch.rb
@@ -19,6 +19,9 @@ module RedmineCategoryTree
 
 			module InstanceMethods
 				def find_name_by_reflection_with_issue_categories(field, id)
+          unless id.present?
+            return nil
+          end
 					if field == 'category'
 					  category = IssueCategory.find(id)
 					  return render_issue_category_with_tree_inline(category)


### PR DESCRIPTION
The Issue show page threw an error 500 (could not find Issue Category with ID nil) when accessing an Issue which has a history entry involving the Issue Category field. It occurs when the history states the Category change from or to an empty value.

A simple nil value check was introduced in the overridden IssueHelper method to prevent this from happening.
